### PR TITLE
Pull-Request to Issue #3

### DIFF
--- a/.msmtprc
+++ b/.msmtprc
@@ -1,0 +1,17 @@
+# Default settings for msmtp
+defaults
+auth           on
+tls            on
+tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile        ~/.msmtp.log
+
+# Account settings
+account        monitor-netstack
+host           maildb01.netstack.de
+port           587
+from           xxx@netstack.de
+user           xxx@netstack.de
+password       xxx
+
+# Set a default account
+account default : monitor-netstack

--- a/backupfiles_to_nfs.sh
+++ b/backupfiles_to_nfs.sh
@@ -1,168 +1,138 @@
 #!/bin/bash
-#
-# BackupNFS Tool 0.2
-#
-# Programm von Netstack GmbH written by Andreas Pfeiffer
-#
-# Dieses Programm führt Datei Backups zu einem NFS Share durch
-#
+# BackupNFS Tool 0.3 - NFS-Sicherung
+# Programm von Netstack GmbH
+
 ################# CONFIG #####################
+nfsmount="192.168.0.1:/backupshare"
+nfsmountdir="/data/nfs_backup"
+hostname="$(hostname -f)"
+backupdir="$nfsmountdir/$hostname"
+datadir=(/path/to/files /path/to/files/2)
+datenbank=(dbname dbname2)
+date1="$(date +%a)"
+date2="$(date +%A %d.%m.%Y)"
+dbuser="DBUSER"
+dbpass="DBPASS"
+email="monitor@example.com"
+mailsubject="Backup - $hostname"
+mailtext="/tmp/mailtext.txt"
 
-backupdir="$nfsmountdir/$hostname"               # Verzeichniss wo die Backups abgelegt werden, es werden automatisch unterordner "mysql" und "files" erstellt.
-datadir=(/path/to/files /path/to/files/2 )       # Welche Ordner sollen gesichert werden
-datenbank=(dbname dbnam2)                        # Datenbanken welche gesichert werden sollen
-date1=$(date +%a)                                # Datumsformat welches an die Dateien angehangen wird
-hostname=$(hostname -f)                          # Hostname
-dbuser=DBUSER                                    # Datenbank User
-dbpass=DBPASS                                    # Datenbank Passwort
-mailsubject="Backup - $hostname"                 # Mail Betreff
-mailtext=/tmp/mailtext.txt                       # Mailtext zum Versand
-email=monitor@example.com                        # Empfaenger der Status Mails
-date2=$(date +%A" "%d.%m.%Y)                     # Datum für E-Mail
-nfsmount="192.168.0.1:/backupshare"              # NFS server + mount mount
-nfsmountdir=/path/to/backup/                     # Ordner fuer NFS-Share
+################# FUNCTIONS #####################
 
-################# CONFIG END #################
+log_message() {
+    echo -e "$1" | tee -a "$mailtext"
+}
 
-# Function to check if NFS packages are installed
-check_nfs_packages() {
-    if ! dpkg -l | grep -q nfs-common; then
-        echo "NFS packages not installed. Installing..."
-        sudo apt-get update
-        sudo apt-get install -y nfs-common
+send_mail() {
+    (
+        echo "To: $email"
+        echo "Subject: $mailsubject"
+        echo "Content-Type: text/plain"
+        echo
+        cat $mailtext
+    ) | msmtp $email
+}
+
+check_and_install_package() {
+    local pkg="$1"
+    if ! dpkg -l | grep -q "$pkg"; then
+        log_message "Installing $pkg..."
+        sudo apt-get update && sudo apt-get install -y "$pkg"
         if [ $? -ne 0 ]; then
-            echo "Failed to install NFS packages. Exiting..."
+            log_message "Failed to install $pkg. Exiting..."
+            send_mail
             exit 1
         fi
     fi
 }
 
-# Run the NFS package check function
-check_nfs_packages
-
-# Reset Error Variable
-error="0"
-
-# Clear mailtext
-echo " " > $mailtext
-
-# Aktuelles Datum
-echo "#############################################################" >> $mailtext
-echo "Backup Script from $hostname - $date2" >> $mailtext
-echo "#############################################################" >> $mailtext
-echo "" >> $mailtext
-
-# Check Backupdir
-if [ ! -d $nfsmountdir ]; then
-    echo -n "Create Backupdirectory ... " >> $mailtext
-    mkdir -p $nfsmountdir
-    if [ ! -d $nfsmountdir ]; then
-        echo -n "Error - Cant create nfs directory" >> $mailtext
-        # send mail on Error 
-        cat $mailtext | mail -s "$mailsubject" $email
-        exit 1
+create_directory() {
+    local dir="$1"
+    if [ ! -d "$dir" ]; then
+        mkdir -p "$dir"
+        if [ $? -ne 0 ]; then
+            log_message "Error creating directory: $dir"
+            send_mail
+            exit 1
+        fi
     fi
-    echo -n "done" >> $mailtext
-    echo "\n" >> $mailtext
-fi
+}
 
-# Mount NFS to backupdir
-echo -n "mount nfs share $nfsmount ... " >> $mailtext
-mount $nfsmount $nfsmountdir
-if [ $? -ne 0 ]; then
-    echo -n " error" >> $mailtext
-    echo "\n" >> $mailtext
-    # send mail on Error 
-    cat $mailtext | mail -s "$mailsubject" $email
-    exit 1
-fi
-echo -n " done" >> $mailtext
-echo "\n" >> $mailtext
-
-# Check Backupdir
-if [ ! -d $backupdir ]; then
-    echo -n "Create Backupdirectory ... " >> $mailtext
-    mkdir -p $backupdir
-    if [ ! -d $backupdir ]; then
-        echo -n "Error - Cant create backupdirectory" >> $mailtext
-        # send mail on Error 
-        cat $mailtext | mail -s "$mailsubject" $email
-        exit 1
-    fi
-    echo -n "done" >> $mailtext
-    echo "\n" >> $mailtext
-fi
-
-# Check Backupdir for mysql
-if [ ! -d $backupdir/mysql ]; then
-    echo -n "Create Backupdirectory for mysql ... " >> $mailtext
-    mkdir -p $backupdir/mysql
-    if [ ! -d $backupdir/mysql ]; then
-        echo -n "Error - Cant create backupdirectory for mysql" >> $mailtext
-        # send mail on Error 
-        cat $mailtext | mail -s "$mailsubject" $email
-        exit 1
-    fi
-    echo -n "done" >> $mailtext
-    echo "\n" >> $mailtext
-fi
-
-# Check Backupdir for files
-if [ ! -d $backupdir/files ]; then
-    echo -n "Create Backupdirectory for files ... " >> $mailtext
-    mkdir -p $backupdir/files
-    if [ ! -d $backupdir/files ]; then
-        echo -n "Error - Cant create backupdirectory for files" >> $mailtext
-        # send mail on Error 
-        cat $mailtext | mail -s "$mailsubject" $email
-        exit 1
-    fi
-    echo -n "done" >> $mailtext
-    echo "\n" >> $mailtext
-fi
-
-######################
-# Start Files backup #
-######################
-
-# Count datadir's from config
-countdir=${#datadir[*]}
-
-for (( j=0; j<$countdir; j++ ))
-do
-    filesdir=${datadir[$j]}
-    # echo "";
-    # Make backup from files dir
-    name=$(basename $filesdir)
-    echo -n "make backup from $filesdir ..." >> $mailtext
-    tar -Pczf $backupdir/files/${name}_$date1.tar.gz $filesdir
+mount_nfs() {
+    mount | grep -q "$nfsmountdir"
     if [ $? -ne 0 ]; then
-        echo -n " error" >> $mailtext
-        echo "\n" >> $mailtext
-        # send mail on Error 
-        cat $mailtext | mail -s "$mailsubject" $email
-        exit 1
-    fi
-    echo -n " done" >> $mailtext
-    echo "\n" >> $mailtext
-done
-
-# Umount NFS share
-umount $nfsmountdir
-
-# Mailversand
-check_ssmtp_packages() {
-    if ! dpkg -l | grep -q msmtp; then
-        echo "msmtp packages not installed. Installing..."
-        sudo apt-get update
-        sudo apt-get install -y msmtp
+        log_message "Mounting NFS share $nfsmount to $nfsmountdir..."
+        mount "$nfsmount" "$nfsmountdir"
         if [ $? -ne 0 ]; then
-            echo "Failed to install msmtp packages. Exiting..."
+            log_message "Error mounting NFS share. Exiting..."
+            send_mail
             exit 1
         fi
     fi
 }
 
-echo -e "Subject: $mailsubject\n\n$mailtext" | msmtp -t email
+backup_files() {
+    for dir in "${datadir[@]}"; do
+        if [ -d "$dir" ]; then
+            local sanitized_dir="${dir%/}"  # Entfernt abschließenden Slash
+            local name="$(basename "$sanitized_dir")"  # Extrahiert den Ordnernamen
+            if [ -z "$name" ]; then
+                log_message "Error: Unable to extract directory name for path $dir."
+                send_mail
+                exit 1
+            fi
+            log_message "Backing up directory $dir to $backupdir/files/${name}_$date1.tar.gz..."
+            tar -Pczf "$backupdir/files/${name}_$date1.tar.gz" "$dir" --ignore-failed-read --warning=no-file-changed
+            if [ $? -ne 0 ]; then
+                log_message "Error backing up $dir. Exiting..."
+                send_mail
+                exit 1
+            fi
+        else
+            log_message "Error: Directory $dir does not exist. Skipping..."
+        fi
+    done
+}
 
+
+backup_mysql() {
+    for db in "${datenbank[@]}"; do
+        local dump_file="$backupdir/mysql/${db}_$date1.sql"
+        log_message "Creating MySQL dump for database $db..."
+        mysqldump -u"$dbuser" -p"$dbpass" --opt "$db" > "$dump_file"
+        if [ $? -ne 0 ]; then
+            log_message "Error creating MySQL dump for $db. Exiting..."
+            send_mail
+            exit 1
+        fi
+        log_message "Compressing dump file $dump_file..."
+        gzip -f -9 "$dump_file"
+        if [ $? -ne 0 ]; then
+            log_message "Error compressing $dump_file. Exiting..."
+            send_mail
+            exit 1
+        fi
+    done
+}
+
+################# MAIN SCRIPT #####################
+
+>"$mailtext" # Clear mail text
+log_message "Starting backup script for $hostname on $date2"
+
+check_and_install_package "nfs-common"
+check_and_install_package "msmtp"
+
+create_directory "$nfsmountdir"
+mount_nfs
+create_directory "$backupdir"
+create_directory "$backupdir/mysql"
+create_directory "$backupdir/files"
+
+backup_files
+backup_mysql
+
+umount "$nfsmountdir"
+log_message "Backup completed successfully."
+send_mail
 exit 0

--- a/backupfiles_to_nfs.sh
+++ b/backupfiles_to_nfs.sh
@@ -151,6 +151,18 @@ done
 umount $nfsmountdir
 
 # Mailversand
-# cat $mailtext | mail -s "$mailsubject" $email
+check_ssmtp_packages() {
+    if ! dpkg -l | grep -q msmtp; then
+        echo "msmtp packages not installed. Installing..."
+        sudo apt-get update
+        sudo apt-get install -y msmtp
+        if [ $? -ne 0 ]; then
+            echo "Failed to install msmtp packages. Exiting..."
+            exit 1
+        fi
+    fi
+}
+
+echo -e "Subject: $mailsubject\n\n$mailtext" | msmtp -t email
 
 exit 0

--- a/backuptool.sh
+++ b/backuptool.sh
@@ -1,200 +1,118 @@
 #!/bin/bash
-#
-# Backup Tool 2.0
-#
-# Programm von Netstack GmbH written by Andreas Pfeiffer
-#
-# Dieses Programm wurde für Datenbank backups mehrerer Datenbanken vorgesehen!
-# Ab Version 1.2 gibt es auch MYSQL-Checks
-# Ab Version 2.0 sind auch Ordnerbackups moeglich
-#
+# Backup Tool 0.3 - Lokale Speicherung
+# Programm von Netstack GmbH
+
 ################# CONFIG #####################
+hostname="$(hostname -f)"
+backupdir="/local_backup/$hostname"
+datadir=(/path/to/files /path/to/files/2)
+datenbank=(dbname dbname2)
+date1="$(date +%a)"
+date2="$(date +%A %d.%m.%Y)"
+dbuser="DBUSER"
+dbpass="DBPASS"
+email="monitor@example.com"
+mailsubject="Backup - $hostname"
+mailtext="/tmp/mailtext.txt"
 
-backupdir=/data/backup                # Verzeichniss wo die Backups abgelegt werden, es werden automatisch unterordner "mysql" und "files" erstellt.
-datenbank=(dbname dbnam2)             # Datenbanken welche gesichert werden sollen
-datadir=(/path/to/webdir1 /path/to/webdir2)    # Welche Ordner sollen gesichert werden
-dbuser=DBUSER                         # Datenbank User
-dbpass=DBPASS                         # Datenbank Passwort
-date1=$(date +%a)                     # Datumsformat welches an die Dateien angehangen wird
-hostname=$(hostname -f)               # Hostname
-mailsubject="MYSQL-Backup - $hostname"        # Mail Betreff
-mailtext=/tmp/mailtext.txt            # Mailtext zum Versand
-email=EMAIL@ADRESSE                   # Empfaenger der Status Mails
-date2=$(date +%A" "%d.%m.%Y)          # Datum für E-Mail
+################# FUNCTIONS #####################
 
-################# CONFIG END #################
+log_message() {
+    echo -e "$1" | tee -a "$mailtext"
+}
 
-# Set PATH
-export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+send_mail() {
+    (
+        echo "To: $email"
+        echo "Subject: $mailsubject"
+        echo "Content-Type: text/plain"
+        echo
+        cat $mailtext
+    ) | msmtp $email
+}
 
-# Clear mailtext
-echo " " > $mailtext;
-
-# Aktuelles Datum
-echo "#############################################################" >> $mailtext
-echo "MYSQL Backup Script from $hostname - "$date2 >> $mailtext
-echo "#############################################################" >> $mailtext
-echo "" >> $mailtext
-
-# Check Backupdir
-if test -d $backupdir; then
-    echo "";
-else
-    echo -n "Create Backupdirectory ... " >> $mailtext
-    mkdir -p $backupdir
-    if test -d $backupdir; then
-        echo "done" >> $mailtext
-        echo "" >> $mailtext
-    else
-        echo "Error - Can't create backup directory" >> $mailtext
-        exit 1;
-    fi
-fi
-
-# Check Backupdir for mysql
-if test -d $backupdir/mysql; then
-    echo "";
-else
-    echo -n "Create Backupdirectory for mysql ... " >> $mailtext
-    mkdir -p $backupdir/mysql
-    if test -d $backupdir/mysql; then
-        echo "done" >> $mailtext
-        echo "" >> $mailtext
-    else
-        echo "Error - Can't create backup directory for mysql" >> $mailtext
-        exit 1;
-    fi
-fi
-
-# Check Backupdir for files
-if test -d $backupdir/files; then
-    echo "";
-else
-    echo -n "Create Backupdirectory for files ... " >> $mailtext
-    mkdir -p $backupdir/files
-    if test -d $backupdir/files; then
-        echo "done" >> $mailtext
-        echo "" >> $mailtext
-    else
-        echo "Error - Can't create backup directory for files" >> $mailtext
-        exit 1;
-    fi
-fi
-
-######################
-# Start Files backup #
-######################
-
-# count datadir's from config
-countdir=${#datadir[*]}
-
-for (( j=0; j<$countdir; j++ )); do
-    # reset Error Variable TODO Error handling
-    error="0"
-    filesdir=${datadir[$j]}
-    # make backup from files dir
-    name=$(basename $filesdir)
-    echo -n "make backup from $filesdir ..." >> $mailtext
-    tar -Pczf $backupdir/files/$name'_'$date1.tar.gz $filesdir
-    if [ $? -eq 0 ]; then
-        echo "done" >> $mailtext
-        echo "" >> $mailtext
-    else
-        echo "error" >> $mailtext
-        echo "" >> $mailtext
-    fi
-done
-
-######################
-# Start MYSQL Backup #
-######################
-
-# clear mysql checkfile
-echo "" > /tmp/mysqlcheck
-
-# count databases from config
-count=${#datenbank[*]}
-
-for (( i=0; i<$count; i++ )); do
-    # reset Error Variable
-    dumperror="0"
-    db=${datenbank[$i]}
-    # Check MYSQL DB
-    echo -n "Check Mysql Database: \"$db\" ... " >> $mailtext
-    mysqlcheck -s -u$dbuser -p$dbpass $db >> /tmp/mysqlcheck
-
-    if [ $? -eq 0 ]; then
-        mysqlcheck=$(cat /tmp/mysqlcheck)
-        if [ -n "$mysqlcheck" ]; then
-            echo "Error -> Details am Ende der Mail" >> $mailtext
-            echo "" >> $mailtext
-        else
-            echo "OK" >> $mailtext
-            echo "" >> $mailtext
-        fi
-    else
-        echo "Error" >> $mailtext
-        echo "" >> $mailtext
-    fi
-
-    # Dump MYSQL DB
-    echo -n "create dump for db: \"$db\" ... " >> $mailtext
-    mysqldump -u$dbuser -p$dbpass --opt $db > $backupdir/mysql/$db'_'$date1.sql
-    if [ $? -eq 0 ]; then
-        echo "done" >> $mailtext
-        sqlfile=$backupdir/mysql/$db'_'$date1.sql
-        echo "" >> $mailtext
-    else
-        echo "Error" >> $mailtext
-        dumperror="1"
-        echo "" >> $mailtext
-    fi
-
-    # Gzip MYSQL Dump
-    echo -n "gzip dump for db: \"$db\" ... " >> $mailtext
-    if [ $dumperror -eq 0 ]; then
-        gzip -f -9 $sqlfile
-        if [ $? -eq 0 ]; then
-            echo "done" >> $mailtext
-            echo "" >> $mailtext
-        else
-            echo "Error" >> $mailtext
-            echo "" >> $mailtext
-        fi
-    else
-        echo "Error" >> $mailtext
-        echo "" >> $mailtext
-    fi
-
-    if [ -n "$mysqlcheck" ]; then
-        echo "" >> $mailtext
-        echo "##############################################################" >> $mailtext
-        echo "Mysql Check Details: " >> $mailtext
-        echo "##############################################################" >> $mailtext
-        echo "" >> $mailtext
-        cat /tmp/mysqlcheck >> $mailtext
-    fi
-done
-
-# Mailversand
-check_ssmtp_packages() {
-    if ! dpkg -l | grep -q msmtp; then
-        echo "msmtp packages not installed. Installing..."
-        sudo apt-get update
-        sudo apt-get install -y msmtp
+check_and_install_package() {
+    local pkg="$1"
+    if ! dpkg -l | grep -q "$pkg"; then
+        log_message "Installing $pkg..."
+        sudo apt-get update && sudo apt-get install -y "$pkg"
         if [ $? -ne 0 ]; then
-            echo "Failed to install msmtp packages. Exiting..."
+            log_message "Failed to install $pkg. Exiting..."
+            send_mail
             exit 1
         fi
     fi
 }
 
-(
-  echo "To: $email"
-  echo "Subject: $mailsubject"
-  echo "Content-Type: text/plain"
-  echo
-  cat $mailtext
-) | msmtp $email
+create_directory() {
+    local dir="$1"
+    if [ ! -d "$dir" ]; then
+        mkdir -p "$dir"
+        if [ $? -ne 0 ]; then
+            log_message "Error creating directory: $dir"
+            send_mail
+            exit 1
+        fi
+    fi
+}
 
+backup_files() {
+    for dir in "${datadir[@]}"; do
+        if [ -d "$dir" ]; then
+            local sanitized_dir="${dir%/}"  # Entfernt abschließenden Slash
+            local name="$(basename "$sanitized_dir")"  # Extrahiert den Ordnernamen
+            if [ -z "$name" ]; then
+                log_message "Error: Unable to extract directory name for path $dir."
+                send_mail
+                exit 1
+            fi
+            log_message "Backing up directory $dir to $backupdir/files/${name}_$date1.tar.gz..."
+            tar -Pczf "$backupdir/files/${name}_$date1.tar.gz" "$dir" --ignore-failed-read --warning=no-file-changed
+            if [ $? -ne 0 ]; then
+                log_message "Error backing up $dir. Exiting..."
+                send_mail
+                exit 1
+            fi
+        else
+            log_message "Error: Directory $dir does not exist. Skipping..."
+        fi
+    done
+}
+
+backup_mysql() {
+    for db in "${datenbank[@]}"; do
+        local dump_file="$backupdir/mysql/${db}_$date1.sql"
+        log_message "Creating MySQL dump for database $db..."
+        mysqldump -u"$dbuser" -p"$dbpass" --opt "$db" > "$dump_file"
+        if [ $? -ne 0 ]; then
+            log_message "Error creating MySQL dump for $db. Exiting..."
+            send_mail
+            exit 1
+        fi
+        log_message "Compressing dump file $dump_file..."
+        gzip -f -9 "$dump_file"
+        if [ $? -ne 0 ]; then
+            log_message "Error compressing $dump_file. Exiting..."
+            send_mail
+            exit 1
+        fi
+    done
+}
+
+################# MAIN SCRIPT #####################
+
+>"$mailtext" # Clear mail text
+log_message "Starting backup script for $hostname on $date2"
+
+check_and_install_package "msmtp"
+
+create_directory "$backupdir"
+create_directory "$backupdir/mysql"
+create_directory "$backupdir/files"
+
+backup_files
+backup_mysql
+
+log_message "Backup completed successfully."
+send_mail
 exit 0

--- a/backuptool.sh
+++ b/backuptool.sh
@@ -189,5 +189,12 @@ check_ssmtp_packages() {
     fi
 }
 
-echo -e "Subject: $mailsubject\n\n$mailtext" | msmtp -t email
+(
+  echo "To: $email"
+  echo "Subject: $mailsubject"
+  echo "Content-Type: text/plain"
+  echo
+  cat $mailtext
+) | msmtp $email
+
 exit 0

--- a/backuptool.sh
+++ b/backuptool.sh
@@ -177,6 +177,17 @@ for (( i=0; i<$count; i++ )); do
 done
 
 # Mailversand
-cat $mailtext | mail -s "$mailsubject" $email
+check_ssmtp_packages() {
+    if ! dpkg -l | grep -q msmtp; then
+        echo "msmtp packages not installed. Installing..."
+        sudo apt-get update
+        sudo apt-get install -y msmtp
+        if [ $? -ne 0 ]; then
+            echo "Failed to install msmtp packages. Exiting..."
+            exit 1
+        fi
+    fi
+}
 
+echo -e "Subject: $mailsubject\n\n$mailtext" | msmtp -t email
 exit 0

--- a/backuptool.sh
+++ b/backuptool.sh
@@ -10,198 +10,173 @@
 #
 ################# CONFIG #####################
 
-backupdir=/data/backup	 			# Verzeichniss wo die Backups abgelegt werden, es werden automatisch unterordner "mysql" und "files" erstellt.
-datenbank=(dbname dbnam2)			# Datenbanken welche gesichert werden sollen
-datadir=(/path/to/webdir1 /path/to/webdir2)	# Welche Ordner sollen gesichert werden
-dbuser=DBUSER					# Datenbank User
-dbpass=DBPASS					# Datenbank Passwort
-date1=$(date +%a)				# Datumsformat welches an die Dateien angehangen wird
-hostname=$(hostname -f)				# Hostname
-mailsubject="MYSQL-Backup - $hostname"		# Mail Betreff
-mailtext=/tmp/mailtext.txt 			# Mailtext zum Versand
-email=EMAIL@ADRESSE	 			# Empfaenger der Status Mails
-date2=$(date +%A" "%d.%m.%Y)			# Datum für E-Mail
+backupdir=/data/backup                # Verzeichniss wo die Backups abgelegt werden, es werden automatisch unterordner "mysql" und "files" erstellt.
+datenbank=(dbname dbnam2)             # Datenbanken welche gesichert werden sollen
+datadir=(/path/to/webdir1 /path/to/webdir2)    # Welche Ordner sollen gesichert werden
+dbuser=DBUSER                         # Datenbank User
+dbpass=DBPASS                         # Datenbank Passwort
+date1=$(date +%a)                     # Datumsformat welches an die Dateien angehangen wird
+hostname=$(hostname -f)               # Hostname
+mailsubject="MYSQL-Backup - $hostname"        # Mail Betreff
+mailtext=/tmp/mailtext.txt            # Mailtext zum Versand
+email=EMAIL@ADRESSE                   # Empfaenger der Status Mails
+date2=$(date +%A" "%d.%m.%Y)          # Datum für E-Mail
 
 ################# CONFIG END #################
 
-#Clear mailtext
+# Set PATH
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+# Clear mailtext
 echo " " > $mailtext;
 
-#Aktuelles Datum
+# Aktuelles Datum
 echo "#############################################################" >> $mailtext
 echo "MYSQL Backup Script from $hostname - "$date2 >> $mailtext
 echo "#############################################################" >> $mailtext
 echo "" >> $mailtext
 
 # Check Backupdir
-if test -d $backupdir
-then
-        echo "";
+if test -d $backupdir; then
+    echo "";
 else
-        echo -n "Create Backupdirectory ... " >> $mailtext
-        mkdir $backupdir
-	if test -d $backupdir
-	then
-        	echo -n "done" >> $mailtext
-		echo "\n" >> $mailtext
-	else
-		echo -n "Error - Cant create backupdirectory" >> $mailtext
-		exit 1;
-	fi
-
+    echo -n "Create Backupdirectory ... " >> $mailtext
+    mkdir -p $backupdir
+    if test -d $backupdir; then
+        echo "done" >> $mailtext
+        echo "" >> $mailtext
+    else
+        echo "Error - Can't create backup directory" >> $mailtext
+        exit 1;
+    fi
 fi
-# Check Backupdir for mysql
-if test -d $backupdir/mysql
-then
-        echo "";
-else
-        echo -n "Create Backupdirectory for mysql ... " >> $mailtext
-        mkdir $backupdir/mysql
-	if test -d $backupdir/mysql
-	then
-        	echo -n "done" >> $mailtext
-		echo "\n" >> $mailtext
-	else
-		echo -n "Error - Cant create backupdirectory for mysql" >> $mailtext
-		exit 1;
-	fi
 
+# Check Backupdir for mysql
+if test -d $backupdir/mysql; then
+    echo "";
+else
+    echo -n "Create Backupdirectory for mysql ... " >> $mailtext
+    mkdir -p $backupdir/mysql
+    if test -d $backupdir/mysql; then
+        echo "done" >> $mailtext
+        echo "" >> $mailtext
+    else
+        echo "Error - Can't create backup directory for mysql" >> $mailtext
+        exit 1;
+    fi
 fi
 
 # Check Backupdir for files
-if test -d $backupdir/files
-then
-        echo "";
+if test -d $backupdir/files; then
+    echo "";
 else
-        echo -n "Create Backupdirectory for files ... " >> $mailtext
-        mkdir $backupdir/files
-	if test -d $backupdir/files
-	then
-        	echo -n "done" >> $mailtext
-		echo "\n" >> $mailtext
-	else
-		echo -n "Error - Cant create backupdirectory for files" >> $mailtext
-		exit 1;
-	fi
-
+    echo -n "Create Backupdirectory for files ... " >> $mailtext
+    mkdir -p $backupdir/files
+    if test -d $backupdir/files; then
+        echo "done" >> $mailtext
+        echo "" >> $mailtext
+    else
+        echo "Error - Can't create backup directory for files" >> $mailtext
+        exit 1;
+    fi
 fi
 
 ######################
 # Start Files backup #
 ######################
 
-#count datadir's from config
-countdir=${#datadir[*]};
+# count datadir's from config
+countdir=${#datadir[*]}
 
-for (( j=0; j<$countdir; j++ ))
-do
-	#reset Error Variable TODO Error handling
-	error="0";
-	filesdir=${datadir[$j]}
-	#echo "";
-	#make backup from files dir
-	name=$(basename $filesdir)
-	echo -n "make backup from $filesdir ..." >> $mailtext
-	tar -Pczf  $backupdir/files/$name'_'$date1.tar.gz $filesdir
-	if [ $? == "0" ]
-	then
-		echo -n " done" >> $mailtext
-		echo "\n" >> $mailtext
-	else
-		echo -n " error" >> $mailtext
-		echo "\n" >> $mailtext
-	fi
+for (( j=0; j<$countdir; j++ )); do
+    # reset Error Variable TODO Error handling
+    error="0"
+    filesdir=${datadir[$j]}
+    # make backup from files dir
+    name=$(basename $filesdir)
+    echo -n "make backup from $filesdir ..." >> $mailtext
+    tar -Pczf $backupdir/files/$name'_'$date1.tar.gz $filesdir
+    if [ $? -eq 0 ]; then
+        echo "done" >> $mailtext
+        echo "" >> $mailtext
+    else
+        echo "error" >> $mailtext
+        echo "" >> $mailtext
+    fi
 done
-
 
 ######################
 # Start MYSQL Backup #
 ######################
 
-#clear mysql checkfile
+# clear mysql checkfile
 echo "" > /tmp/mysqlcheck
 
-#count databaeses from config
-count=${#datenbank[*]};
+# count databases from config
+count=${#datenbank[*]}
 
-for (( i=0; i<$count; i++ ))
-do
-	#reset Error Variable
-	dumperror="0";
+for (( i=0; i<$count; i++ )); do
+    # reset Error Variable
+    dumperror="0"
+    db=${datenbank[$i]}
+    # Check MYSQL DB
+    echo -n "Check Mysql Database: \"$db\" ... " >> $mailtext
+    mysqlcheck -s -u$dbuser -p$dbpass $db >> /tmp/mysqlcheck
 
-	db=${datenbank[$i]}
-	echo " ";
-	# Check MYSQL DB
-		echo -n "Check Mysql Database: \"$db\" ... " >> $mailtext
-		mysqlcheck -s -u$dbuser -p$dbpass $db >> /tmp/mysqlcheck
+    if [ $? -eq 0 ]; then
+        mysqlcheck=$(cat /tmp/mysqlcheck)
+        if [ -n "$mysqlcheck" ]; then
+            echo "Error -> Details am Ende der Mail" >> $mailtext
+            echo "" >> $mailtext
+        else
+            echo "OK" >> $mailtext
+            echo "" >> $mailtext
+        fi
+    else
+        echo "Error" >> $mailtext
+        echo "" >> $mailtext
+    fi
 
-		if [ $? == "0" ]
-		then
-			mysqlcheck=$(cat /tmp/mysqlcheck)
-			if [ -n "$mysqlcheck" ];
-			then
-				echo -n " Error -> Details am Ende der Mail" >> $mailtext
-				echo "" >> $mailtext
-			else
-				echo -n " OK" >> $mailtext
-				echo "" >> $mailtext
-			fi
-		else
-			echo -n " Error " >> $mailtext
-			echo "" >> $mailtext
-		fi
+    # Dump MYSQL DB
+    echo -n "create dump for db: \"$db\" ... " >> $mailtext
+    mysqldump -u$dbuser -p$dbpass --opt $db > $backupdir/mysql/$db'_'$date1.sql
+    if [ $? -eq 0 ]; then
+        echo "done" >> $mailtext
+        sqlfile=$backupdir/mysql/$db'_'$date1.sql
+        echo "" >> $mailtext
+    else
+        echo "Error" >> $mailtext
+        dumperror="1"
+        echo "" >> $mailtext
+    fi
 
-	# Dump MYSQL DB
-		echo -n "create dump for db: \"$db\" ... " >> $mailtext
-		mysqldump -u$dbuser -p$dbpass --opt $db > $backupdir/mysql/$db'_'$date1.sql
-		if [ $? == "0" ]
-		then
-			echo -n " done " >> $mailtext
-			sqlfile=$backupdir/mysql/$db'_'$date1.sql
-			echo " " >> $mailtext
-		else
-			echo -n " Error " >> $mailtext
-			dumperror="1";
-			echo " " >> $mailtext
-		fi
+    # Gzip MYSQL Dump
+    echo -n "gzip dump for db: \"$db\" ... " >> $mailtext
+    if [ $dumperror -eq 0 ]; then
+        gzip -f -9 $sqlfile
+        if [ $? -eq 0 ]; then
+            echo "done" >> $mailtext
+            echo "" >> $mailtext
+        else
+            echo "Error" >> $mailtext
+            echo "" >> $mailtext
+        fi
+    else
+        echo "Error" >> $mailtext
+        echo "" >> $mailtext
+    fi
 
-	# Gzip MYSQL Dump
-		echo -n "gzip dump for db: \"$db\" ... " >> $mailtext
-		if [ $dumperror == "0" ]
-		then
-	                gzip -f -9 $sqlfile
-	                if [ $? == "0" ]
-	                then
-	                        echo -n " done " >> $mailtext
-	                        echo " " >> $mailtext
-	                else
-	                        echo -n " Error " >> $mailtext
-	                        echo " " >> $mailtext
-	                fi
-		else
-			echo -n " Error " >> $mailtext
-			echo " " >> $mailtext
-		fi
-
-
-
-
-if [ -n "$mysqlcheck" ];
-then
-
-	echo " " >> $mailtext
-	echo "##############################################################" >> $mailtext
-	echo "Mysql Check Details: " >> $mailtext
-	echo "##############################################################" >> $mailtext
-	echo "" >> $mailtext
-	cat /tmp/mysqlcheck >> $mailtext
-fi
-
+    if [ -n "$mysqlcheck" ]; then
+        echo "" >> $mailtext
+        echo "##############################################################" >> $mailtext
+        echo "Mysql Check Details: " >> $mailtext
+        echo "##############################################################" >> $mailtext
+        echo "" >> $mailtext
+        cat /tmp/mysqlcheck >> $mailtext
+    fi
 done
 
 # Mailversand
-
 cat $mailtext | mail -s "$mailsubject" $email
 
-exit 0;
+exit 0


### PR DESCRIPTION
The issue #3 be resolved by using `msmtp` as an alternative to the `mail` command. This approach does not require a local Mail Transfer Agent (MTA) and can send emails via an SMTP server. 


Below is the modified code that uses `msmtp`:

```bash
(
  echo "To: $email"
  echo "Subject: $mailsubject"
  echo "Content-Type: text/plain"
  echo
  cat $mailtext
) | msmtp $email
```

#### Steps to Implement the Solution:

1. Install `msmtp` on your system. For Debian-based distributions, you can use:
   ```bash
   sudo apt-get install msmtp
   ```

2. Configure `msmtp` by creating or editing the configuration file `~/.msmtprc` with the necessary SMTP server details:
   ```
   account default
   host smtp.yourserver.com
   port 587
   from youremail@yourdomain.com
   auth on
   user youremail@yourdomain.com
   password yourpassword
   tls on
   tls_trust_file /etc/ssl/certs/ca-certificates.crt
   ```

3. Ensure the configuration file has the correct permissions:
   ```bash
   chmod 600 ~/.msmtprc
   ```

4. Update the `backup-tool.sh` script with the provided code snippet.

5. Test the script to ensure emails are sent successfully without relying on a local MTA.

This solution ensures that the backup process can run smoothly in environments without an MTA, maintaining the reliabilityand effectiveness of your backup notifications.

